### PR TITLE
Post error message to Slack on RHACM error

### DIFF
--- a/deployment/rhacmstackem_deployment.yaml.sh
+++ b/deployment/rhacmstackem_deployment.yaml.sh
@@ -59,7 +59,7 @@ spec:
       template:
         spec:
           serviceAccountName: ${SERVICE_ACCOUNT_NAME}
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: rhacmstackem
             image: quay.io/dhaiduce/rhacmstackem


### PR DESCRIPTION
A repeated deployment of a failed deployment probably won't work, so it makes more sense to post this to Slack and let the users debug it.