### PR TITLE
Fix string handling; Store E2E password in a Secret

### DIFF
--- a/rhacmstackem.sh
+++ b/rhacmstackem.sh
@@ -97,7 +97,7 @@ if [[ "${ERROR_CODE}" != "1" ]]; then
       oc patch -n openshift-config oauth cluster --type json --patch '[{"op":"add","path":"/spec/identityProviders","value":[]}]'
     fi
     if [ ! $(oc -n openshift-config get oauth cluster -o jsonpath='{.spec.identityProviders[*].name}' | grep -o "${RBAC_IDP_NAME}") ]; then
-      oc patch -n openshift-config oauth cluster --type json --patch '[{"op":"add","path":"/spec/identityProviders/-","value":{"name":"'${RBAC_IDP_NAME}'","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"e2e-users"}}}}]'
+      oc patch -n openshift-config oauth cluster --type json --patch '[{"op":"add","path":"/spec/identityProviders/-","value":{"name":"'"${RBAC_IDP_NAME}"'","mappingMethod":"claim","type":"HTPasswd","htpasswd":{"fileData":{"name":"e2e-users"}}}}]'
     fi
     oc apply --validate=false -k "${RBAC_DIR}"
     export RBAC_INFO="*RBAC Users*: e2e-<cluster-admin/admin/edit/view>-<cluster/ns>\\\n*RBAC Password*: ${RBAC_PASS}\\\n"
@@ -108,13 +108,13 @@ if [[ "${ERROR_CODE}" != "1" ]]; then
     export KUBECONFIG=${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig
     oc apply -f ./resources/consolenotification.yaml
     if [[ "${CONSOLE_BANNER_TEXT}" != "default" ]]; then
-      oc patch consolenotification.console.openshift.io/rhacmstackem --type json --patch '[{"op":"remove", "path":"/spec/link"},{"op":"replace", "path":"/spec/text", "value":"'${CONSOLE_BANNER_TEXT}'"}]'
+      oc patch consolenotification.console.openshift.io/rhacmstackem --type json --patch '[{"op":"remove", "path":"/spec/link"},{"op":"replace", "path":"/spec/text", "value":"'"${CONSOLE_BANNER_TEXT}"'"}]'
     fi
     if [[ -n "${CONSOLE_BANNER_COLOR}" ]]; then
-      oc patch consolenotification.console.openshift.io/rhacmstackem --type json --patch '[{"op":"replace", "path":"/spec/color", "value":"'${CONSOLE_BANNER_COLOR}'"}]'
+      oc patch consolenotification.console.openshift.io/rhacmstackem --type json --patch '[{"op":"replace", "path":"/spec/color", "value":"'"${CONSOLE_BANNER_COLOR}"'"}]'
     fi
     if [[ -n "${CONSOLE_BANNER_BGCOLOR}" ]]; then
-      oc patch consolenotification.console.openshift.io/rhacmstackem --type json --patch '[{"op":"replace", "path":"/spec/backgroundColor", "value":"'${CONSOLE_BANNER_BGCOLOR}'"}]'
+      oc patch consolenotification.console.openshift.io/rhacmstackem --type json --patch '[{"op":"replace", "path":"/spec/backgroundColor", "value":"'"${CONSOLE_BANNER_BGCOLOR}"'"}]'
     fi
   fi
 fi

--- a/rhacmstackem.sh
+++ b/rhacmstackem.sh
@@ -91,6 +91,7 @@ if [[ "${ERROR_CODE}" != "1" ]]; then
         htpasswd -b "${HTPASSWD_FILE}" e2e-${role}-${access} ${RBAC_PASS}
       done
     done
+    oc create secret generic e2e-pass --from-literal=password="${RBAC_PASS}" -n openshift-config || true
     oc create secret generic e2e-users --from-file=htpasswd="${HTPASSWD_FILE}" -n openshift-config || true
     rm "${HTPASSWD_FILE}"
     if [[ -z "$(oc -n openshift-config get oauth cluster -o jsonpath='{.spec.identityProviders}')" ]]; then


### PR DESCRIPTION
- Since the banner text was an unquoted string, any spaces resulted in an error
- Also stores the E2E password in a Secret for discoverability when the script does not run to completion successfully