### PR TITLE
chore: migrate to local cert issuer script

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+knowledge_base:
+  linked_repositories:
+    - repository: dhaiducek/startrhacm
+      instructions: Wrapper script to provision an Openshift cluster and install Red Hat Advanced Cluster Management for Kubernetes (RHACM).
+    - repository: stolostron/deploy
+      instructions: Install script for Red Hat Advanced Cluster Management for Kubernetes (RHACM) located at start.sh.
+    - repository: stolostron/lifeguard
+      instructions: Scripts for managing ClusterPools and ClusterClaims to provision Openshift clusters.
+    - repository: openshift/hive
+      instructions: The controller and API for ClusterPools and ClusterClaims to provision Openshift clusters from cloud providers.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 # Add RHACMStackEm script and YAML resources
-ADD rhacmstackem.sh .
-ADD resources/ resources/
+COPY rhacmstackem.sh .
+COPY resources/ resources/
+COPY utils/ utils/
 
 # Install microdnf packages: tar/gzip, curl, git, jq, htpasswd
 RUN microdnf update -y && microdnf install -y tar gzip curl git jq httpd-tools skopeo

--- a/deployment/rhacmstackem_deployment.yaml.sh
+++ b/deployment/rhacmstackem_deployment.yaml.sh
@@ -41,6 +41,45 @@ else
   printf "\n* Slack credentials not provided--skipping creation of Slack secret YAML\n"
 fi
 
+if [[ "${INSTALL_CERTIFICATE}" == "true" ]] && [[ -n "${HOSTED_ZONE_ID}" ]] && [[ -n "${AWS_SECRET}" ]]; then
+cat >rhacmstackem-issuer.yaml <<EOF
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: public-cluster-issuer
+  namespace: ${CLUSTERPOOL_TARGET_NAMESPACE}
+spec:
+  acme:
+    email: acm-cicd@redhat.com
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: haproxy
+      selector:
+        matchLabels:
+          use-http01-solver: "true"
+    - dns01:
+        cnameStrategy: Follow
+        route53:
+          accessKeyIDSecretRef:
+            key: aws_access_key_id
+            name: ${AWS_SECRET}
+          region: us-east-1
+          hostedZoneID: ${HOSTED_ZONE_ID}
+          secretAccessKeySecretRef:
+            key: aws_secret_access_key
+            name: ${AWS_SECRET}
+      selector:
+        matchLabels:
+          use-dns01-solver: "true"
+EOF
+else
+  printf "\n* Certificate installation not requested--skipping creation of Issuer YAML\n"
+fi
+
 cat >rhacmstackem-cronjob.yaml <<EOF
 apiVersion: batch/v1beta1
 kind: CronJob

--- a/rhacmstackem.sh
+++ b/rhacmstackem.sh
@@ -10,7 +10,6 @@ git clone https://github.com/dhaiducek/startrhacm.git
 git clone https://github.com/stolostron/lifeguard.git
 git clone "https://${GIT_USER}:${GIT_TOKEN}@github.com/stolostron/pipeline.git"
 git clone https://github.com/stolostron/deploy.git
-git clone https://github.com/nitin-dhevar/cluster-cert.git
 
 export LIFEGUARD_PATH=/lifeguard
 export RHACM_PIPELINE_PATH=/pipeline
@@ -76,15 +75,19 @@ echo "$(date) ##### Running StartRHACM"
 export DISABLE_CLUSTER_CHECK="true"
 ./startrhacm/startrhacm.sh || ERROR_CODE=1
 
+export CLUSTER_KUBECONFIG_FILE="${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig"
+if [[ -f "${CLUSTER_KUBECONFIG_FILE}" ]]; then
+  export KUBECONFIG="${CLUSTER_KUBECONFIG_FILE}"
+fi
+
 # If there weren't failures, continue with cluster setup
-if [[ "${ERROR_CODE}" != "1" ]]; then
+if [[ "${ERROR_CODE}" != "1" ]] && [[ -n "${KUBECONFIG}" ]]; then
   # Point to claimed cluster and set up RBAC users
   if [[ "${RBAC_SETUP:-"true"}" == "true" ]]; then
     RBAC_IDP_NAME=${RBAC_IDP_NAME:-"e2e-htpasswd"}
     echo "$(date) ##### Setting up RBAC users"
     export RBAC_PASS
     RBAC_PASS=$(head /dev/urandom | tr -dc 'A-Za-z0-9' | head -c $((32 + RANDOM % 8)))
-    export KUBECONFIG=${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig
     RBAC_DIR="./resources/rbac"
     HTPASSWD_FILE="${RBAC_DIR}/htpasswd"
     touch "${HTPASSWD_FILE}"
@@ -108,7 +111,6 @@ if [[ "${ERROR_CODE}" != "1" ]]; then
 
   # Add a custom RHACMStackEm banner to Openshift
   if [[ -n "${CONSOLE_BANNER_TEXT}" ]]; then
-    export KUBECONFIG=${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig
     oc apply -f ./resources/consolenotification.yaml
     if [[ "${CONSOLE_BANNER_TEXT}" != "default" ]]; then
       if [[ "${PRESERVE_CONSOLE_BANNER_LINK}" != "true" ]]; then
@@ -128,11 +130,6 @@ fi
 # Send cluster information to Slack
 if [[ -n "${SLACK_URL}" ]] || { [[ -n "${SLACK_TOKEN}" ]] && [[ -n "${SLACK_CHANNEL_ID}" ]]; }; then
   echo "$(date) ##### Posting information to Slack"
-  # Point to claimed cluster and retrieve cluster information
-  KUBECONFIG_FILE="${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig"
-  if [[ -f "${KUBECONFIG_FILE}" ]]; then
-    export KUBECONFIG="${KUBECONFIG_FILE}"
-  fi
   # Set greeting based on error code from StartRHACM
   if [[ "${ERROR_CODE}" == "1" ]]; then
     GREETING=":red_circle: RHACM deployment failed. The \`${CLUSTERCLAIM_NAME}\` cluster for $(date "+%A, %B %d, %Y") may need to be debugged before use or a redeployment may be in progress."
@@ -190,29 +187,11 @@ if [[ -n "${SLACK_URL}" ]] || { [[ -n "${SLACK_TOKEN}" ]] && [[ -n "${SLACK_CHAN
   fi
 fi
 
-if [[ "${INSTALL_CERTIFICATE}" == "true" ]] && [[ "${ERROR_CODE}" != "1" ]]; then
-  # Fetch ClusterDeployment and Hosted Zone name from ClusterPool host
+if [[ "${INSTALL_CERTIFICATE}" == "true" ]] && [[ -f "${CLUSTER_KUBECONFIG_FILE}" ]] && [[ "${ERROR_CODE}" != "1" ]]; then
   unset KUBECONFIG
   echo "* Installing cluster certificate"
-
-  clusterdeployment=$(oc get  clusterclaims.hive.openshift.io "${CLUSTERCLAIM_NAME}" -n "${CLUSTERPOOL_TARGET_NAMESPACE}" -o jsonpath='{.spec.namespace}')
-  hosted_zone_name=$(oc get -n "${clusterdeployment}" clusterdeployments.hive.openshift.io "${clusterdeployment}" -o jsonpath='{.spec.baseDomain}')
-
-  echo "ClusterDeployment name: ${clusterdeployment}"
-  echo "Hosted zone name: ${hosted_zone_name}"
-
-  if [[ -z "${clusterdeployment}" || -z "${hosted_zone_name}" ]]; then
-    echo "ERROR: Could not determine clusterdeployment namespace or baseDomain from ClusterClaim"
-    exit ${ERROR_CODE}
-  fi
-
-  # Add certificate
-  ./cluster-cert/apply-apps-cert.sh \
-    "${clusterdeployment}" \
-    "${hosted_zone_name}" \
-    "${LIFEGUARD_PATH}/clusterclaims/${CLUSTERCLAIM_NAME}/kubeconfig" \
-    "${CLUSTERPOOL_TARGET_NAMESPACE}" \
-    "${CLUSTERCLAIM_LIFETIME}"
+  # Add certificate, but ignore errors
+  /utils/apply-apps-cert.sh || true
 fi
 
 exit ${ERROR_CODE}

--- a/utils/apply-apps-cert.sh
+++ b/utils/apply-apps-cert.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${CLUSTERCLAIM_NAME?:CLUSTERCLAIM_NAME must be set}"
+: "${CLUSTERPOOL_TARGET_NAMESPACE?:CLUSTERPOOL_TARGET_NAMESPACE must be set}"
+: "${CLUSTERCLAIM_LIFETIME?:CLUSTERCLAIM_LIFETIME must be set}"
+: "${CLUSTER_KUBECONFIG_FILE?:CLUSTER_KUBECONFIG_FILE must be set}"
+
+# Fetch ClusterDeployment and Hosted Zone name from ClusterPool host
+oc project
+
+clusterdeployment=$(oc get clusterclaims.hive.openshift.io "${CLUSTERCLAIM_NAME}" -n "${CLUSTERPOOL_TARGET_NAMESPACE}" -o jsonpath='{.spec.namespace}')
+hosted_zone_name=$(oc get -n "${clusterdeployment}" clusterdeployments.hive.openshift.io "${clusterdeployment}" -o jsonpath='{.spec.baseDomain}')
+certificate_name="apps-domain-tls-cert-${clusterdeployment}"
+certificate_duration="${CLUSTERCLAIM_LIFETIME:-168h0m0s}" 
+
+echo "* ClusterDeployment name: ${clusterdeployment}"
+echo "* Hosted zone name: ${hosted_zone_name}"
+
+if [[ -z "${clusterdeployment}" || -z "${hosted_zone_name}" ]]; then
+  echo "ERROR: Could not determine clusterdeployment namespace or baseDomain from ClusterClaim ${CLUSTERCLAIM_NAME}"
+  exit 1
+fi
+
+echo "* Cleaning up existing certificates..."
+oc delete certificates.cert-manager.io -n "${CLUSTERPOOL_TARGET_NAMESPACE}" -l "cluster=${CLUSTERCLAIM_NAME}"
+
+cat <<EOF | oc apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${certificate_name}
+  namespace: ${CLUSTERPOOL_TARGET_NAMESPACE}
+  labels:
+    use-dns01-solver: "true"
+    cluster: ${CLUSTERCLAIM_NAME}
+spec:
+  secretName: ${certificate_name}-secret
+  subject:
+    organizations:
+    - Open Cluster Management
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - apps.${clusterdeployment}.${hosted_zone_name}
+    - "*.apps.${clusterdeployment}.${hosted_zone_name}"
+  duration: ${certificate_duration}
+  privateKey:
+    algorithm: "RSA"
+    size: 2048
+  issuerRef:
+    name: public-cluster-issuer
+    kind: Issuer
+EOF
+
+echo "* Waiting for certificate to be ready on collective..."
+oc wait --for=condition=Ready "certificates.cert-manager.io/${certificate_name}" -n "${CLUSTERPOOL_TARGET_NAMESPACE}" --timeout=900s
+
+# Get the certificate secret name from the certificate status
+echo "* Getting certificate secret name from certificate status..."
+cert_secret_name=$(oc get certificates.cert-manager.io "${certificate_name}" -n "${CLUSTERPOOL_TARGET_NAMESPACE}" -o jsonpath='{.spec.secretName}')
+
+# Extract the certificate secret from collective
+echo "* Extracting certificate secret from collective..."
+cert_secret_yaml=$(oc get secret "${cert_secret_name}" -n "${CLUSTERPOOL_TARGET_NAMESPACE}" -o yaml | 
+  yq '.metadata |= del(.creationTimestamp, .namespace, .ownerReferences, .resourceVersion, .uid)')
+
+# Switch to claimed cluster
+echo "* Switching to claimed cluster to apply certificate..."
+export KUBECONFIG="${CLUSTER_KUBECONFIG_FILE}"
+oc project
+
+echo "* Copying certificate secret to openshift-ingress namespace on claimed cluster..."
+echo "${cert_secret_yaml}" | oc apply -n openshift-ingress -f -
+
+echo "* Patching the certificate into the IngressController on claimed cluster..."
+oc patch ingresscontrollers.operator.openshift.io default \
+  --type=merge -p \
+  "{\"spec\":{\"defaultCertificate\": {\"name\": \"${cert_secret_name}\"}}}" \
+  -n openshift-ingress-operator
+
+echo "* Successfully created certificate on collective and applied to claimed cluster."


### PR DESCRIPTION
This allows us to use a self-managed namespaced Issuer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated issuance and application of wildcard TLS certificates to claimed cluster ingresses.

* **Chores**
  * Refactored certificate workflow into a reusable utility and integrated it into deployment flow.
  * Made certificate issuer creation conditional based on install settings.
  * Included utility tooling in the container image.
  * Enabled weekly Dependabot updates for GitHub Actions.
  * Added repository knowledge-base configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->