### PR TITLE
fix: use `oc config` to view context

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,9 +3,5 @@ knowledge_base:
   linked_repositories:
     - repository: dhaiducek/startrhacm
       instructions: Wrapper script to provision an Openshift cluster and install Red Hat Advanced Cluster Management for Kubernetes (RHACM).
-    - repository: stolostron/deploy
-      instructions: Install script for Red Hat Advanced Cluster Management for Kubernetes (RHACM) located at start.sh.
-    - repository: stolostron/lifeguard
-      instructions: Scripts for managing ClusterPools and ClusterClaims to provision Openshift clusters.
     - repository: openshift/hive
       instructions: The controller and API for ClusterPools and ClusterClaims to provision Openshift clusters from cloud providers.

--- a/rhacmstackem.sh
+++ b/rhacmstackem.sh
@@ -191,7 +191,7 @@ if [[ "${INSTALL_CERTIFICATE}" == "true" ]] && [[ -f "${CLUSTER_KUBECONFIG_FILE}
   unset KUBECONFIG
   echo "* Installing cluster certificate"
   # Add certificate, but ignore errors
-  /utils/apply-apps-cert.sh || true
+  /utils/apply-apps-cert.sh || echo "ERROR: Failed to install cluster certificate"
 fi
 
 exit ${ERROR_CODE}

--- a/utils/apply-apps-cert.sh
+++ b/utils/apply-apps-cert.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 : "${CLUSTER_KUBECONFIG_FILE?:CLUSTER_KUBECONFIG_FILE must be set}"
 
 # Fetch ClusterDeployment and Hosted Zone name from ClusterPool host
-oc project
+current_context="$(oc config current-context)"
+echo "* Current context: ${current_context}"
 
 clusterdeployment=$(oc get clusterclaims.hive.openshift.io "${CLUSTERCLAIM_NAME}" -n "${CLUSTERPOOL_TARGET_NAMESPACE}" -o jsonpath='{.spec.namespace}')
 hosted_zone_name=$(oc get -n "${clusterdeployment}" clusterdeployments.hive.openshift.io "${clusterdeployment}" -o jsonpath='{.spec.baseDomain}')
@@ -70,7 +71,8 @@ cert_secret_yaml=$(oc get secret "${cert_secret_name}" -n "${CLUSTERPOOL_TARGET_
 # Switch to claimed cluster
 echo "* Switching to claimed cluster to apply certificate..."
 export KUBECONFIG="${CLUSTER_KUBECONFIG_FILE}"
-oc project
+current_context="$(oc config current-context)"
+echo "* Current context: ${current_context}"
 
 echo "* Copying certificate secret to openshift-ingress namespace on claimed cluster..."
 echo "${cert_secret_yaml}" | oc apply -n openshift-ingress -f -


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Script now displays the active Kubernetes context at key steps for better visibility.
  * Installation process now emits a clear error message if cluster certificate installation fails, while preserving overall flow.
  * Removed two linked repository references from the CI/configuration metadata to simplify linked-repo list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->